### PR TITLE
Enable caching and PDFs

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Set up pandoc
         uses: r-lib/actions/setup-pandoc@master
 
+      - name: Set up TinyTex
+        uses: r-lib/actions/setup-tinytex@v1
+
+      - name: Install X11 dependencies on MacOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install --cask xquartz
+
       - name: Cache Renv packages
         uses: actions/cache@v2
         with:
@@ -64,3 +72,12 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: _site
+
+      - name: Upload LaTeX logs
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: latex-logs
+          path: |
+            *.log
+            *.tex

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - master
 
+## If you need to clear the cache, update the number inside cache-version as
+## discussed at https://github.com/r-lib/actions/issues/86.
+## Note that you can always run a GHA test without the cache by using the word
+## "/nocache" in the commit message.
+env:
+  cache-version: 'cache-v1'
+
 jobs:
   render:
     runs-on: macOS-latest
@@ -34,11 +41,12 @@ jobs:
           brew install --cask xquartz
 
       - name: Cache Renv packages
+        if: "!contains(github.event.head_commit.message, '/nocache')"
         uses: actions/cache@v2
         with:
           path: $HOME/.local/share/renv
-          key: r-${{ hashFiles('renv.lock') }}
-          restore-keys: r-
+          key: ${{ env.cache-version }}-renv-${{ hashFiles('renv.lock') }}
+          restore-keys: ${{ env.cache-version }}-renv-
 
       - name: Install packages
         run: |
@@ -54,11 +62,12 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache knitr results
+        if: "!contains(github.event.head_commit.message, '/nocache')"
         uses: actions/cache@v2
         with:
           path: '**/*_cache'
-          key: knitr-${{ runner.os }}
-          restore-keys: knitr-
+          key: ${{ env.cache-version }}-knitr-${{ runner.os }}
+          restore-keys: ${{ env.cache-version }}-knitr-
 
       - name: Render site
         run: |

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -45,6 +45,12 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
+      - name: Cache knitr results
+        uses: actions/cache@v2
+        with:
+          path: *_cache
+          key: knitr-${{ runner.os }}
+
       - name: Render site
         run: |
           rmarkdown::render_site()

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -48,8 +48,9 @@ jobs:
       - name: Cache knitr results
         uses: actions/cache@v2
         with:
-          path: *_cache
+          path: '**/*_cache'
           key: knitr-${{ runner.os }}
+          restore-keys: knitr-
 
       - name: Render site
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Rmd-website
 
+<!-- Badge to show GHA rendering status: adapt URL to your own repo! -->
+
+[![Render and Deploy](https://github.com/statOmics/Rmd-website/workflows/Render%20and%20Deploy/badge.svg)](https://github.com/statOmics/Rmd-website/actions)
+
+
 An RMarkdown-based website rendered using GitHub Actions
 
 https://statomics.github.io/Rmd-website/

--- a/_session-info.Rmd
+++ b/_session-info.Rmd
@@ -1,0 +1,10 @@
+# Session info {-}
+
+<details><summary>Session info</summary>
+
+```{r session_info, echo=FALSE, cache=FALSE}
+Sys.time()
+sessioninfo::session_info()
+```
+
+</details>

--- a/_site.yml
+++ b/_site.yml
@@ -34,5 +34,8 @@ output:
       include:
         after_body: footer.html
       css: style.css
+  pdf_document:
+    toc: false
+    number_sections: true
 new_session: true
 exclude: ["install.R"]

--- a/about.Rmd
+++ b/about.Rmd
@@ -2,7 +2,10 @@
 title: "About This Website"
 output:
     html_document:
+        code_download: false
         toc: false
+        number_sections: false
+        code_folding: "none"
 ---
 
 More about this website.

--- a/example.Rmd
+++ b/example.Rmd
@@ -46,3 +46,10 @@ __Note that this should be used with caution, as caches may become invalid when 
 ## Run with caching enabled
 Sys.time()
 ```
+
+<!-- Include common Session Information Rmd fragment by including the following code chunk: -->
+<!-- See https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html#rmd-partials -->
+
+```{r, child="_session-info.Rmd"}
+
+```

--- a/example.Rmd
+++ b/example.Rmd
@@ -32,3 +32,17 @@ ggplot(mtcars, aes(mpg, disp, col = as.factor(cyl))) +
 ```
 
 Note that the `echo = FALSE` parameter was added to the code chunk to prevent printing of the R code that generated the plot.
+
+
+# Caching
+
+The GHA workflow maintains cached *knitr* results between subsequent runs to
+reduce runtime. Caching can be enabled by specifying `cache=TRUE` in the code
+chunk header.
+
+__Note that this should be used with caution, as caches may become invalid when code is changed, potentially leading to unsuspected results.__
+
+```{r, cache=TRUE}
+## Run with caching enabled
+Sys.time()
+```

--- a/example.Rmd
+++ b/example.Rmd
@@ -1,9 +1,7 @@
 ---
 title: "Example"
-author: 
-    - name: Milan Malfait
-      affiliation: Ghent University 
-date: ""
+author: Milan Malfait, Ghent University
+date: '`r format(Sys.Date(), "%B %d, %Y")`'
 ---
 
 ```{r setup, include=FALSE}

--- a/example.Rmd
+++ b/example.Rmd
@@ -4,7 +4,6 @@ author:
     - name: Milan Malfait
       affiliation: Ghent University 
 date: ""
-output: html_document
 ---
 
 ```{r setup, include=FALSE}

--- a/index.Rmd
+++ b/index.Rmd
@@ -5,6 +5,7 @@ output:
         code_download: false
         toc: false
         number_sections: false
+        code_folding: "none"
 ---
 
 Hello, Website!

--- a/index.Rmd
+++ b/index.Rmd
@@ -13,3 +13,11 @@ Hello, Website!
 For more information about simple R Markdown websites, please read the documentation at https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html.
 
 Please also note that simple R Markdown sites are _not_ based on **blogdown**. They are probably good for websites with only a few Rmd documents. For larger-scale and more sophisticated websites (such as blogs), you may want to use **blogdown** instead: https://github.com/rstudio/blogdown.
+
+***
+
+### Contents
+
+<!-- Placeholder of Table of Contents on the homepage, with links to the actual page and PDF version -->
+
+- [Example](./example.html) ([PDF](./example.pdf))

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.1.0",
+    "Version": "4.1.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -25,10 +25,10 @@
     },
     "R6": {
       "Package": "R6",
-      "Version": "2.5.0",
+      "Version": "2.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b203113193e70978a696b2809525649d"
+      "Hash": "470851b6d5d0ac559e9d01bb352b4021"
     },
     "RColorBrewer": {
       "Package": "RColorBrewer",
@@ -46,10 +46,10 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.0.0",
+      "Version": "3.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "096829b701eec2d2b4538be63de97e75"
+      "Hash": "e3ae5d68dea0c55a12ea12a9fda02e61"
     },
     "colorspace": {
       "Package": "colorspace",
@@ -106,6 +106,13 @@
       "Repository": "CRAN",
       "Hash": "c98eb5133d9cb9e1622b8691487f11bb"
     },
+    "fastmap": {
+      "Package": "fastmap",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "77bd60a6157420d4ffa93b27cf6a58b8"
+    },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.3.5",
@@ -136,10 +143,10 @@
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.1.1",
+      "Version": "0.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "af2c2531e55df5cf230c4b5444fc973c"
+      "Hash": "526c484233f42522278ab06fb185cb26"
     },
     "isoband": {
       "Package": "isoband",
@@ -227,10 +234,10 @@
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.6.1",
+      "Version": "1.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8672ae02bd20f6479bce2d06c7ff1401"
+      "Hash": "43f228eb4b49093d1c8a5c93cae9efe9"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
@@ -246,10 +253,10 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.13.2",
+      "Version": "0.14.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "079cb1f03ff972b30401ed05623cbe92"
+      "Hash": "30e5eba91b67f7f4d75d31de14bbfbdc"
     },
     "rlang": {
       "Package": "rlang",
@@ -260,10 +267,10 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.9",
+      "Version": "2.10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "912c09266d5470516df4df7a303cde92"
+      "Hash": "1fb097f233ee98968f8e5d0bcd42df6d"
     },
     "scales": {
       "Package": "scales",
@@ -274,10 +281,10 @@
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.6.2",
+      "Version": "1.7.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "9df5e6f9a7fa11b84adf0429961de66a"
+      "Hash": "ebaccb577da50829a3bb1b8296f318a5"
     },
     "stringr": {
       "Package": "stringr",
@@ -288,24 +295,24 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.1.2",
+      "Version": "3.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "349b40a9f144516d537c875e786ec8b8"
+      "Hash": "5e8ad5621e5c94b24ec07b88eee13df8"
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.32",
+      "Version": "0.33",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "db9a6f2cf147751322d22c9f6647c7bd"
+      "Hash": "6e0ad90ac5669e35d5456cb61b295acb"
     },
     "utf8": {
       "Package": "utf8",
-      "Version": "1.2.1",
+      "Version": "1.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c3ad47dc6da0751f18ed53c4613e3ac7"
+      "Hash": "c9c462b759a5cc844ae25b5942654d13"
     },
     "vctrs": {
       "Package": "vctrs",
@@ -336,10 +343,10 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.24",
+      "Version": "0.25",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "88cdb9779a657ad80ad942245fffba31"
+      "Hash": "853d45ffff0a9af1e0af017cd359f75e"
     },
     "yaml": {
       "Package": "yaml",

--- a/renv.lock
+++ b/renv.lock
@@ -279,6 +279,13 @@
       "Repository": "CRAN",
       "Hash": "6f76f71042411426ec8df6c54f34e6dd"
     },
+    "sessioninfo": {
+      "Package": "sessioninfo",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "308013098befe37484df72c39cf90d6e"
+    },
     "stringi": {
       "Package": "stringi",
       "Version": "1.7.4",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,13 +2,27 @@
 local({
 
   # the requested version of renv
-  version <- "0.13.2"
+  version <- "0.14.0"
 
   # the project directory
   project <- getwd()
 
+  # allow environment variable to control activation
+  activate <- Sys.getenv("RENV_ACTIVATE_PROJECT")
+  if (!nzchar(activate)) {
+
+    # don't auto-activate when R CMD INSTALL is running
+    if (nzchar(Sys.getenv("R_INSTALL_PKG")))
+      return(FALSE)
+
+  }
+
+  # bail if activation was explicitly disabled
+  if (tolower(activate) %in% c("false", "f", "0"))
+    return(FALSE)
+
   # avoid recursion
-  if (!is.na(Sys.getenv("RENV_R_INITIALIZING", unset = NA)))
+  if (nzchar(Sys.getenv("RENV_R_INITIALIZING")))
     return(invisible(TRUE))
 
   # signal that we're loading renv during R startup


### PR DESCRIPTION
* Enable caching of knitr results in the GHA (works more or less, but the caches will only be kept for a few days)
* Include a common 'Session info' Rmd fragment for reuse in other Rmd files
* Add ability to generate PDF files for Rmd's using TinyTex and include example
* Some small cosmetic changes